### PR TITLE
feat(#2)member 엔터티 추가, kakao oauth2 개발을 위해 키 추가, 카카오 로그인 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
 	// 페이징 처리를 위한 PageHelper 의존성 추가
 	implementation 'com.github.pagehelper:pagehelper-spring-boot-starter:1.4.6'
+
+	// 카카오 로그인 설정을 위해 추가
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/bst/bobsoolting/common/exception/ErrorCode.java
+++ b/src/main/java/bst/bobsoolting/common/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     EMAIL_AUTH_CODE_INVALID(40117, HttpStatus.UNAUTHORIZED, "인증 번호가 올바르지 않습니다. 다시 요청해주세요."),
     LOGIN_HISTORY_FAILURE(40118, HttpStatus.UNAUTHORIZED, "로그인 이력 저장에 실패했습니다."), // 로그인 이력 기록 실패
     LOGGED_OUT(40119, HttpStatus.UNAUTHORIZED, "로그아웃된 토큰입니다."), // 로그아웃된 토큰인 경우
+    NEW_MEMBER_REGISTRATION_REQUIRED(40120, HttpStatus.UNAUTHORIZED, "신규 회원입니다. 추가 정보를 입력해 주세요."),
 
     // 403: 권한 부족 (Forbidden)
     FORBIDDEN_ROLE(40300, HttpStatus.FORBIDDEN, "요청한 리소스에 대한 권한이 없습니다."), // 사용자가 요청한 리소스에 대한 권한이 없는 경우

--- a/src/main/java/bst/bobsoolting/member/command/application/controller/MemberCommandController.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/controller/MemberCommandController.java
@@ -1,7 +1,14 @@
 package bst.bobsoolting.member.command.application.controller;
 
+import bst.bobsoolting.member.command.application.dto.MemberDTO;
+import bst.bobsoolting.member.command.application.mapper.MemberConverter;
+import bst.bobsoolting.member.command.application.service.MemberCommandService;
+import bst.bobsoolting.member.command.domain.vo.request.RequestAdditionalRegisterVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +17,15 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RequiredArgsConstructor
 public class MemberCommandController {
+
+    private final MemberCommandService memberCommandService;
+    private final MemberConverter memberConverter;
+
+    @PostMapping("/complete-registration")
+    public ResponseEntity<?> completeRegistration(@RequestBody RequestAdditionalRegisterVO info) {
+        log.info("추가 회원가입 정보 수신: {}", info);
+        MemberDTO newMember = memberConverter.fromAdditionalVOToEntity(info);
+        memberCommandService.createMember(newMember);
+        return ResponseEntity.ok("회원가입 완료");
+    }
 }

--- a/src/main/java/bst/bobsoolting/member/command/application/controller/MemberCommandController.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/controller/MemberCommandController.java
@@ -4,8 +4,10 @@ import bst.bobsoolting.member.command.application.dto.MemberDTO;
 import bst.bobsoolting.member.command.application.mapper.MemberConverter;
 import bst.bobsoolting.member.command.application.service.MemberCommandService;
 import bst.bobsoolting.member.command.domain.vo.request.RequestAdditionalRegisterVO;
+import bst.bobsoolting.member.command.domain.vo.response.ResponseCreateMemberVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,8 +26,9 @@ public class MemberCommandController {
     @PostMapping("/complete-registration")
     public ResponseEntity<?> completeRegistration(@RequestBody RequestAdditionalRegisterVO info) {
         log.info("추가 회원가입 정보 수신: {}", info);
-        MemberDTO newMember = memberConverter.fromAdditionalVOToEntity(info);
-        memberCommandService.createMember(newMember);
-        return ResponseEntity.ok("회원가입 완료");
+        MemberDTO newMemberDTO = memberConverter.fromAdditionalVOToEntity(info);
+        MemberDTO member = memberCommandService.createMember(newMemberDTO);
+        ResponseCreateMemberVO memberVO = memberConverter.fromEntityToCreateVO(member);
+        return ResponseEntity.status(HttpStatus.OK).body(memberVO);
     }
 }

--- a/src/main/java/bst/bobsoolting/member/command/application/controller/MemberCommandController.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/controller/MemberCommandController.java
@@ -1,0 +1,13 @@
+package bst.bobsoolting.member.command.application.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/member")
+@Slf4j
+@RequiredArgsConstructor
+public class MemberCommandController {
+}

--- a/src/main/java/bst/bobsoolting/member/command/application/dto/MemberDTO.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/dto/MemberDTO.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @ToString
 @Builder
 public class MemberDTO {
-    private Long memberId;
+    private String memberId;
     private String kakaoId;
     private String nickname;
     private String phone;

--- a/src/main/java/bst/bobsoolting/member/command/application/dto/MemberDTO.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/dto/MemberDTO.java
@@ -1,0 +1,29 @@
+package bst.bobsoolting.member.command.application.dto;
+
+import bst.bobsoolting.member.command.domain.aggregate.MemberGender;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+public class MemberDTO {
+    private Long memberId;
+    private String loginId;
+    private String password;
+    private String nickname;
+    private String phone;
+    private MemberGender gender;
+    private Date birth;
+    private String university;
+    private String department;
+    private Integer studentNumber;
+    private Float rating;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/bst/bobsoolting/member/command/application/dto/MemberDTO.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/dto/MemberDTO.java
@@ -1,6 +1,7 @@
 package bst.bobsoolting.member.command.application.dto;
 
 import bst.bobsoolting.member.command.domain.aggregate.MemberGender;
+import bst.bobsoolting.member.command.domain.aggregate.MemberRole;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -14,8 +15,7 @@ import java.util.Date;
 @Builder
 public class MemberDTO {
     private Long memberId;
-    private String loginId;
-    private String password;
+    private String kakaoId;
     private String nickname;
     private String phone;
     private MemberGender gender;
@@ -24,6 +24,7 @@ public class MemberDTO {
     private String department;
     private Integer studentNumber;
     private Float rating;
+    private MemberRole memberRole;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/bst/bobsoolting/member/command/application/mapper/MemberConverter.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/mapper/MemberConverter.java
@@ -4,6 +4,7 @@ import bst.bobsoolting.member.command.application.dto.MemberDTO;
 import bst.bobsoolting.member.command.domain.aggregate.MemberRole;
 import bst.bobsoolting.member.command.domain.aggregate.entity.Member;
 import bst.bobsoolting.member.command.domain.vo.request.RequestAdditionalRegisterVO;
+import bst.bobsoolting.member.command.domain.vo.response.ResponseCreateMemberVO;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -37,6 +38,38 @@ public class MemberConverter {
                 .studentNumber(newMemberDTO.getStudentNumber())
                 .rating(newMemberDTO.getRating())
                 .memberRole(newMemberDTO.getMemberRole())
+                .build();
+    }
+
+    public MemberDTO fromEntityToDTO(Member newMember) {
+        return MemberDTO.builder()
+                .memberId(newMember.getMemberId())
+                .kakaoId(newMember.getKakaoId())
+                .nickname(newMember.getNickname())
+                .phone(newMember.getPhone())
+                .gender(newMember.getGender())
+                .birth(newMember.getBirth())
+                .university(newMember.getUniversity())
+                .department(newMember.getDepartment())
+                .studentNumber(newMember.getStudentNumber())
+                .rating(newMember.getRating())
+                .memberRole(newMember.getMemberRole())
+                .build();
+    }
+
+    public ResponseCreateMemberVO fromEntityToCreateVO(MemberDTO member) {
+        return ResponseCreateMemberVO.builder()
+                .memberId(member.getMemberId())
+                .kakaoId(member.getKakaoId())
+                .nickname(member.getNickname())
+                .phone(member.getPhone())
+                .gender(member.getGender())
+                .birth(member.getBirth())
+                .university(member.getUniversity())
+                .department(member.getDepartment())
+                .studentNumber(member.getStudentNumber())
+                .rating(member.getRating())
+                .memberRole(member.getMemberRole())
                 .build();
     }
 }

--- a/src/main/java/bst/bobsoolting/member/command/application/mapper/MemberConverter.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/mapper/MemberConverter.java
@@ -1,7 +1,42 @@
 package bst.bobsoolting.member.command.application.mapper;
 
+import bst.bobsoolting.member.command.application.dto.MemberDTO;
+import bst.bobsoolting.member.command.domain.aggregate.MemberRole;
+import bst.bobsoolting.member.command.domain.aggregate.entity.Member;
+import bst.bobsoolting.member.command.domain.vo.request.RequestAdditionalRegisterVO;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MemberConverter {
+
+    public MemberDTO fromAdditionalVOToEntity(RequestAdditionalRegisterVO info) {
+        return MemberDTO.builder()
+                .kakaoId(info.getKakaoId())
+                .nickname(info.getNickname())
+                .phone(info.getPhone())
+                .gender(info.getGender())
+                .birth(info.getBirth())
+                .university(info.getUniversity())
+                .department(info.getDepartment())
+                .studentNumber(info.getStudentNumber())
+                .rating(0.0f) // 초기 rating(당근 온도 개념)
+                .memberRole(MemberRole.ROLE_USER)
+                .build();
+    }
+
+    public Member fromDTOToEntity(MemberDTO newMemberDTO, String memberId) {
+        return Member.builder()
+                .memberId(memberId)
+                .kakaoId(newMemberDTO.getKakaoId())
+                .nickname(newMemberDTO.getNickname())
+                .phone(newMemberDTO.getPhone())
+                .gender(newMemberDTO.getGender())
+                .birth(newMemberDTO.getBirth())
+                .university(newMemberDTO.getUniversity())
+                .department(newMemberDTO.getDepartment())
+                .studentNumber(newMemberDTO.getStudentNumber())
+                .rating(newMemberDTO.getRating())
+                .memberRole(newMemberDTO.getMemberRole())
+                .build();
+    }
 }

--- a/src/main/java/bst/bobsoolting/member/command/application/mapper/MemberConverter.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/mapper/MemberConverter.java
@@ -1,0 +1,7 @@
+package bst.bobsoolting.member.command.application.mapper;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberConverter {
+}

--- a/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandService.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandService.java
@@ -1,4 +1,7 @@
 package bst.bobsoolting.member.command.application.service;
 
+import bst.bobsoolting.member.command.application.dto.MemberDTO;
+
 public interface MemberCommandService {
+    void createMember(MemberDTO newMember);
 }

--- a/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandService.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandService.java
@@ -1,0 +1,4 @@
+package bst.bobsoolting.member.command.application.service;
+
+public interface MemberCommandService {
+}

--- a/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandService.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandService.java
@@ -3,5 +3,5 @@ package bst.bobsoolting.member.command.application.service;
 import bst.bobsoolting.member.command.application.dto.MemberDTO;
 
 public interface MemberCommandService {
-    void createMember(MemberDTO newMember);
+    MemberDTO createMember(MemberDTO newMember);
 }

--- a/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandServiceImpl.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandServiceImpl.java
@@ -1,11 +1,47 @@
 package bst.bobsoolting.member.command.application.service;
 
+import bst.bobsoolting.common.exception.CommonException;
+import bst.bobsoolting.common.exception.ErrorCode;
+import bst.bobsoolting.member.command.application.dto.MemberDTO;
+import bst.bobsoolting.member.command.application.mapper.MemberConverter;
+import bst.bobsoolting.member.command.domain.aggregate.entity.Member;
+import bst.bobsoolting.member.command.domain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberCommandServiceImpl implements MemberCommandService {
+
+    private final MemberRepository memberRepository;
+    private final MemberConverter memberConverter;
+
+    @Override
+    public void createMember(MemberDTO newMemberDTO) {
+        try {
+            String memberId = generateMemberId();
+            log.info("생성된 memberId: {}", memberId);
+
+            Member newMember = memberConverter.fromDTOToEntity(newMemberDTO, memberId);
+
+            memberRepository.save(newMember);
+            log.info("회원가입 완료: kakaoId={}, memberId={}", newMember.getKakaoId(), newMember.getMemberId());
+        } catch (Exception e) {
+            log.error("회원가입 실패: {}", e.getMessage(), e);
+            throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String generateMemberId() {
+        String datePart = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String uuidPart = UUID.randomUUID().toString().replace("-", "").substring(20);
+
+        return datePart + uuidPart;
+    }
 }

--- a/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandServiceImpl.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandServiceImpl.java
@@ -23,7 +23,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final MemberConverter memberConverter;
 
     @Override
-    public void createMember(MemberDTO newMemberDTO) {
+    public MemberDTO createMember(MemberDTO newMemberDTO) {
         try {
             String memberId = generateMemberId();
             log.info("생성된 memberId: {}", memberId);
@@ -32,6 +32,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
             memberRepository.save(newMember);
             log.info("회원가입 완료: kakaoId={}, memberId={}", newMember.getKakaoId(), newMember.getMemberId());
+            return memberConverter.fromEntityToDTO(newMember);
         } catch (Exception e) {
             log.error("회원가입 실패: {}", e.getMessage(), e);
             throw new CommonException(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandServiceImpl.java
+++ b/src/main/java/bst/bobsoolting/member/command/application/service/MemberCommandServiceImpl.java
@@ -1,0 +1,11 @@
+package bst.bobsoolting.member.command.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberCommandServiceImpl implements MemberCommandService {
+}

--- a/src/main/java/bst/bobsoolting/member/command/domain/aggregate/MemberGender.java
+++ b/src/main/java/bst/bobsoolting/member/command/domain/aggregate/MemberGender.java
@@ -1,0 +1,17 @@
+package bst.bobsoolting.member.command.domain.aggregate;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum MemberGender {
+    MALE("MALE"),
+    FEMALE("FEMALE");
+
+    private final String memberGender;
+
+    MemberGender(String memberGender) { this.memberGender = memberGender; }
+
+    @JsonValue
+    public String getMemberGender() {
+        return memberGender;
+    }
+}

--- a/src/main/java/bst/bobsoolting/member/command/domain/aggregate/MemberRole.java
+++ b/src/main/java/bst/bobsoolting/member/command/domain/aggregate/MemberRole.java
@@ -1,0 +1,6 @@
+package bst.bobsoolting.member.command.domain.aggregate;
+
+public enum MemberRole {
+    ROLE_USER,
+    ROLE_ADMIN
+}

--- a/src/main/java/bst/bobsoolting/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/bst/bobsoolting/member/command/domain/aggregate/entity/Member.java
@@ -1,6 +1,7 @@
 package bst.bobsoolting.member.command.domain.aggregate.entity;
 
 import bst.bobsoolting.member.command.domain.aggregate.MemberGender;
+import bst.bobsoolting.member.command.domain.aggregate.MemberRole;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -21,11 +22,8 @@ public class Member {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
-    @Column(name = "login_id", nullable = false)
-    private String loginId;
-
-    @Column(name = "password", nullable = false)
-    private String password;
+    @Column(name = "kakao_id", nullable = false)
+    private String kakaoId;
 
     @Column(name = "nickname", nullable = false)
     private String nickname;
@@ -51,6 +49,10 @@ public class Member {
 
     @Column(name = "rating", nullable = false)
     private Float rating;
+
+    @Column(name = "member_role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MemberRole memberRole;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/bst/bobsoolting/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/bst/bobsoolting/member/command/domain/aggregate/entity/Member.java
@@ -1,0 +1,71 @@
+package bst.bobsoolting.member.command.domain.aggregate.entity;
+
+import bst.bobsoolting.member.command.domain.aggregate.MemberGender;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Entity
+@Table(name = "member")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Builder
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "login_id", nullable = false)
+    private String loginId;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
+    @Column(name = "phone", nullable = false)
+    private String phone;
+
+    @Column(name = "gender", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MemberGender gender;
+
+    @Column(name = "birth", nullable = false)
+    private Date birth;
+
+    @Column(name = "university", nullable = false)
+    private String university;
+
+    @Column(name = "department", nullable = false)
+    private String department;
+
+    @Column(name = "student_number", nullable = false)
+    private Integer studentNumber;
+
+    @Column(name = "rating", nullable = false)
+    private Float rating;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    private void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/bst/bobsoolting/member/command/domain/aggregate/entity/Member.java
+++ b/src/main/java/bst/bobsoolting/member/command/domain/aggregate/entity/Member.java
@@ -20,7 +20,7 @@ public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    private String memberId;
 
     @Column(name = "kakao_id", nullable = false)
     private String kakaoId;

--- a/src/main/java/bst/bobsoolting/member/command/domain/repository/MemberRepository.java
+++ b/src/main/java/bst/bobsoolting/member/command/domain/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package bst.bobsoolting.member.command.domain.repository;
+
+import bst.bobsoolting.member.command.domain.aggregate.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, String> {
+}

--- a/src/main/java/bst/bobsoolting/member/command/domain/vo/request/RequestAdditionalRegisterVO.java
+++ b/src/main/java/bst/bobsoolting/member/command/domain/vo/request/RequestAdditionalRegisterVO.java
@@ -1,0 +1,31 @@
+package bst.bobsoolting.member.command.domain.vo.request;
+
+import bst.bobsoolting.member.command.domain.aggregate.MemberGender;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class RequestAdditionalRegisterVO {
+    @JsonProperty("kakao_id")
+    private String kakaoId;
+    @JsonProperty("nickname")
+    private String nickname;
+    @JsonProperty("phone")
+    private String phone;
+    @JsonProperty("gender")
+    private MemberGender gender;
+    @JsonProperty("birth")
+    private Date birth;
+    @JsonProperty("university")
+    private String university;
+    @JsonProperty("department")
+    private String department;
+    @JsonProperty("student_number")
+    private Integer studentNumber;
+}

--- a/src/main/java/bst/bobsoolting/member/command/domain/vo/response/ResponseCreateMemberVO.java
+++ b/src/main/java/bst/bobsoolting/member/command/domain/vo/response/ResponseCreateMemberVO.java
@@ -1,0 +1,48 @@
+package bst.bobsoolting.member.command.domain.vo.response;
+
+import bst.bobsoolting.member.command.domain.aggregate.MemberGender;
+import bst.bobsoolting.member.command.domain.aggregate.MemberRole;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class ResponseCreateMemberVO {
+    @JsonProperty("member_id")
+    private String memberId;
+
+    @JsonProperty("kakao_id")
+    private String kakaoId;
+
+    @JsonProperty("nickname")
+    private String nickname;
+
+    @JsonProperty("phone")
+    private String phone;
+
+    @JsonProperty("gender")
+    private MemberGender gender;
+
+    @JsonProperty("birth")
+    private Date birth;
+
+    @JsonProperty("university")
+    private String university;
+
+    @JsonProperty("department")
+    private String department;
+
+    @JsonProperty("student_number")
+    private Integer studentNumber;
+
+    @JsonProperty("rating")
+    private Float rating;
+
+    @JsonProperty("member_role")
+    private MemberRole memberRole;
+}

--- a/src/main/java/bst/bobsoolting/member/query/controller/MemberQueryController.java
+++ b/src/main/java/bst/bobsoolting/member/query/controller/MemberQueryController.java
@@ -1,7 +1,15 @@
 package bst.bobsoolting.member.query.controller;
 
+import bst.bobsoolting.member.query.service.MemberQueryService;
+import bst.bobsoolting.common.exception.CommonException;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +18,34 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RequiredArgsConstructor
 public class MemberQueryController {
+
+    private final MemberQueryService memberQueryService;
+
+    @Operation(description = "카카오 OAuth2 로그인 성공 후 처리")
+    @GetMapping("/loginSuccess")
+    public ResponseEntity<?> loginSuccess(@AuthenticationPrincipal OAuth2User user) {
+        log.info("카카오 로그인 성공: {}", user);
+        try {
+            memberQueryService.processLoginSuccess(user);
+            return ResponseEntity.ok("로그인 성공: " + user.getAttribute("id"));
+        } catch (CommonException e) {
+            log.error("로그인 성공 처리 오류: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 오류", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그인 성공 처리 중 오류가 발생했습니다");
+        }
+    }
+
+    @Operation(description = "카카오 OAuth2 로그인 실패 처리")
+    @GetMapping("/loginFailure")
+    public ResponseEntity<?> loginFailure() {
+        log.info("카카오 로그인 실패");
+        try {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인 실패");
+        } catch (Exception e) {
+            log.error("로그인 실패 처리 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그인 실패 처리 중 오류가 발생했습니다");
+        }
+    }
 }

--- a/src/main/java/bst/bobsoolting/member/query/controller/MemberQueryController.java
+++ b/src/main/java/bst/bobsoolting/member/query/controller/MemberQueryController.java
@@ -1,0 +1,13 @@
+package bst.bobsoolting.member.query.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/member")
+@Slf4j
+@RequiredArgsConstructor
+public class MemberQueryController {
+}

--- a/src/main/java/bst/bobsoolting/member/query/repository/MemberMapper.java
+++ b/src/main/java/bst/bobsoolting/member/query/repository/MemberMapper.java
@@ -1,0 +1,7 @@
+package bst.bobsoolting.member.query.repository;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface MemberMapper {
+}

--- a/src/main/java/bst/bobsoolting/member/query/repository/MemberMapper.java
+++ b/src/main/java/bst/bobsoolting/member/query/repository/MemberMapper.java
@@ -1,7 +1,10 @@
 package bst.bobsoolting.member.query.repository;
 
+import bst.bobsoolting.member.command.domain.aggregate.entity.Member;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface MemberMapper {
+    Member findByKakaoId(@Param("kakaoId") String kakaoId);
 }

--- a/src/main/java/bst/bobsoolting/member/query/service/MemberQueryService.java
+++ b/src/main/java/bst/bobsoolting/member/query/service/MemberQueryService.java
@@ -1,0 +1,4 @@
+package bst.bobsoolting.member.query.service;
+
+public interface MemberQueryService {
+}

--- a/src/main/java/bst/bobsoolting/member/query/service/MemberQueryService.java
+++ b/src/main/java/bst/bobsoolting/member/query/service/MemberQueryService.java
@@ -1,4 +1,7 @@
 package bst.bobsoolting.member.query.service;
 
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
 public interface MemberQueryService {
+    void processLoginSuccess(OAuth2User user);
 }

--- a/src/main/java/bst/bobsoolting/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/bst/bobsoolting/member/query/service/MemberQueryServiceImpl.java
@@ -1,0 +1,11 @@
+package bst.bobsoolting.member.query.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberQueryServiceImpl {
+}

--- a/src/main/java/bst/bobsoolting/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/bst/bobsoolting/member/query/service/MemberQueryServiceImpl.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class MemberQueryServiceImpl {
+public class MemberQueryServiceImpl implements MemberQueryService {
 }

--- a/src/main/java/bst/bobsoolting/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/bst/bobsoolting/member/query/service/MemberQueryServiceImpl.java
@@ -1,11 +1,33 @@
 package bst.bobsoolting.member.query.service;
 
+import bst.bobsoolting.common.exception.CommonException;
+import bst.bobsoolting.common.exception.ErrorCode;
+import bst.bobsoolting.member.command.domain.aggregate.entity.Member;
+import bst.bobsoolting.member.query.repository.MemberMapper; // 예시: MyBatis Mapper
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberQueryServiceImpl implements MemberQueryService {
+
+    private final MemberMapper memberMapper;
+
+    @Override
+    public void processLoginSuccess(OAuth2User user) {
+        Long kakaoIdLong = user.getAttribute("id");
+        String kakaoId = String.valueOf(kakaoIdLong);
+        log.info("로그인 성공 처리 시작. kakaoId: {}", kakaoId);
+
+        Member existingMember = memberMapper.findByKakaoId(kakaoId);
+        if (existingMember == null) {
+            log.info("신규 회원입니다. 추가 정보 입력 필요합니다. kakaoId: {}", kakaoId);
+            throw new CommonException(ErrorCode.NEW_MEMBER_REGISTRATION_REQUIRED);
+        } else {
+            log.info("기존 회원 로그인 성공. kakaoId: {}", kakaoId);
+        }
+    }
 }

--- a/src/main/java/bst/bobsoolting/security/SecurityConfig.java
+++ b/src/main/java/bst/bobsoolting/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -20,29 +21,30 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        // CORS 설정과 CSRF 비활성화
-        http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf.disable());
-
-        // 기본 formLogin과 httpBasic 인증 비활성화 (OAuth2만 사용)
-        http.formLogin(form -> form.disable())
-                .httpBasic(httpBasic -> httpBasic.disable());
-
-        http.authorizeHttpRequests(authz -> authz
-                        .anyRequest().permitAll() // 권한 추가하면서 나눌 예정입니다. 2월 26일 주석 작성
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS))
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .authorizeHttpRequests(authz -> authz
+//                        .requestMatchers("/api/**/admin/**").hasAuthority("ROLE_ADMIN")
+                        .requestMatchers("/api/member/**").authenticated()
+                        .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .defaultSuccessUrl("/loginSuccess")
-                        .failureUrl("/loginFailure")
+                        .defaultSuccessUrl("/api/member/loginSuccess", true)
+                        .failureUrl("/api/member/loginFailure")
                 );
 
         return http.build();
     }
 
+
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:5173"));
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:8080"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowCredentials(true);
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-XSRF-TOKEN"));

--- a/src/main/java/bst/bobsoolting/security/SecurityConfig.java
+++ b/src/main/java/bst/bobsoolting/security/SecurityConfig.java
@@ -1,0 +1,56 @@
+package bst.bobsoolting.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // CORS 설정과 CSRF 비활성화
+        http.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable());
+
+        // 기본 formLogin과 httpBasic 인증 비활성화 (OAuth2만 사용)
+        http.formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable());
+
+        http.authorizeHttpRequests(authz -> authz
+                        .anyRequest().permitAll() // 권한 추가하면서 나눌 예정입니다. 2월 26일 주석 작성
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .defaultSuccessUrl("/loginSuccess")
+                        .failureUrl("/loginFailure")
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:5173"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-XSRF-TOKEN"));
+        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,10 +26,12 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET_KEY}
             client-name: kakao
             authorization-grant-type: authorization_code
-            redirect-uri: "${KAKAO_BASE_URL}/login/oauth2/code/kakao"
+            redirect-uri: ${KAKAO_BASE_URL}/login/oauth2/code/kakao
             scope:
               - profile_nickname
-              - account_email
+              - profile_image
+            client-authentication-method: client_secret_post
+
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,25 @@ spring:
         format_sql: true
     generate-ddl: false
 
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_KEY}
+            client-secret: ${KAKAO_CLIENT_SECRET_KEY}
+            client-name: kakao
+            authorization-grant-type: authorization_code
+            redirect-uri: "${KAKAO_BASE_URL}/login/oauth2/code/kakao"
+            scope:
+              - profile_nickname
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
 
 #  data:
 #    redis:
@@ -31,9 +50,6 @@ logging:
     org.springframework.security: TRACE
     org.mybatis: DEBUG
     java.sql: DEBUG
-
-#jwt:
-#  secret-key: ${JWT_SECRET_KEY}
 
 mybatis:
   mapper-locations: classpath:/bst/bobsoolting/mapper/**/*.xml

--- a/src/main/resources/bst/bobsoolting/mapper/member/MemberMapper.xml
+++ b/src/main/resources/bst/bobsoolting/mapper/member/MemberMapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="bst.bobsoolting.member.query.repository.MemberMapper">
+    <resultMap id="memberResultMap" type="bst.bobsoolting.member.command.domain.aggregate.entity.Member">
+        <id property="memberId" column="member_id"/>
+        <result property="loginId" column="login_id"/>
+        <result property="password" column="password"/>
+        <result property="nickname" column="nickname"/>
+        <result property="phone" column="phone"/>
+        <result property="gender" column="gender" javaType="bst.bobsoolting.member.command.domain.aggregate.MemberGender"/>
+        <result property="birth" column="birth" jdbcType="DATE"/>
+        <result property="university" column="university"/>
+        <result property="department" column="department"/>
+        <result property="studentNumber" column="student_number" jdbcType="INTEGER"/>
+        <result property="rating" column="rating" jdbcType="FLOAT"/>
+        <result property="createdAt" column="created_at" jdbcType="TIMESTAMP"/>
+        <result property="updatedAt" column="updated_at" jdbcType="TIMESTAMP"/>
+    </resultMap>
+
+</mapper>

--- a/src/main/resources/bst/bobsoolting/mapper/member/MemberMapper.xml
+++ b/src/main/resources/bst/bobsoolting/mapper/member/MemberMapper.xml
@@ -4,8 +4,7 @@
 <mapper namespace="bst.bobsoolting.member.query.repository.MemberMapper">
     <resultMap id="memberResultMap" type="bst.bobsoolting.member.command.domain.aggregate.entity.Member">
         <id property="memberId" column="member_id"/>
-        <result property="loginId" column="login_id"/>
-        <result property="password" column="password"/>
+        <result property="kakaoId" column="kakao_id"/>
         <result property="nickname" column="nickname"/>
         <result property="phone" column="phone"/>
         <result property="gender" column="gender" javaType="bst.bobsoolting.member.command.domain.aggregate.MemberGender"/>
@@ -14,8 +13,15 @@
         <result property="department" column="department"/>
         <result property="studentNumber" column="student_number" jdbcType="INTEGER"/>
         <result property="rating" column="rating" jdbcType="FLOAT"/>
+        <result property="memberRole" column="member_role" javaType="bst.bobsoolting.member.command.domain.aggregate.MemberRole"/>
         <result property="createdAt" column="created_at" jdbcType="TIMESTAMP"/>
         <result property="updatedAt" column="updated_at" jdbcType="TIMESTAMP"/>
     </resultMap>
+
+    <select id="findByKakaoId" parameterType="String" resultMap="memberResultMap">
+        SELECT member_id, kakao_id, nickname, phone, gender, birth, university, department, student_number, rating,member_role, created_at, updated_at
+          FROM member
+         WHERE kakao_id = #{kakaoId}
+    </select>
 
 </mapper>


### PR DESCRIPTION
1. 카카오 로그인으로 아이디, 비밀번호 입력 후 동의까지 완료
2. 기존 유저인 경우 : 바로 로그인
3. 신규 유저인 경우 : 예외처리 -> 프론트에서 해당 예외처리가 발생하는 경우 -> 추가 정보를 받는 화면으로 redirect -> 추가 정보를 받아서 다시 api 호출
3-1. 추가 정보를 받은 뒤 신규 유저 등록 요청으로 api 호출 -> 해당 정보들 DB에 저장하는 로직 구현

memberId는 연월일+uuid 12자리 로 이루어진 String 형태입니다.

close #2 